### PR TITLE
Updating getBarCodeUrl with correct google api URL.

### DIFF
--- a/code/rfc6238.php
+++ b/code/rfc6238.php
@@ -77,7 +77,7 @@
 
 
                public static function getBarCodeUrl($username, $domain, $secretkey) {
-                    $url = "https://www.google.com/chart";
+                    $url = "http://chart.apis.google.com/chart";
                     $url = $url."?chs=200x200&chld=M|0&cht=qr&chl=otpauth://totp/";
                     $url = $url.$username . "@" . $domain . "%3Fsecret%3D" . $secretkey;
                     return $url;


### PR DESCRIPTION
Stupid Pull Request system did not make sense.  I wonder what I was not understanding with it.  Either way, I think this is correct.

The down side is that it is http:// not https//    A quick bit of searching says this has been a known problem for years, you can't use it over https this way.

The best solution for a pure (client side) https solution is to curl the image down on the server and then feed to the client over https.
