### PR TITLE
Use more secure random for generateRandomClue

### DIFF
--- a/code/rfc6238.php
+++ b/code/rfc6238.php
@@ -77,8 +77,10 @@
   		$b32 	= "234567QWERTYUIOPASDFGHJKLZXCVBNM";
   		$s 	= "";
 
+ 	$srand = openssl_random_pseudo_bytes($length, $strong);
+
       for ($i = 0; $i < $length; $i++)
-			  $s .= $b32[rand(0,31)];
+			   $s .= $b32[ord($srand[$i]) % 32];
 
         return $s;
     }


### PR DESCRIPTION
Modify generateRandomClue to use a source of true randomness from the openssl series of cryptographic functions. Anytime one is generating secrets that are critical to the functioning of the system security, a cryptographically secure random source should be used. The openssl function is not guaranteed to procedure a crypto secure random, but it *should* in the vast majority of implementations.